### PR TITLE
Instagram posts with multiple images will be forwarded to Discord as unshortened links

### DIFF
--- a/instagram.js
+++ b/instagram.js
@@ -10,6 +10,7 @@ const tinyurl = require("tinyurl");
 const signale = require("signale");
 const Bluebird = require("bluebird");
 const inquirer = require("inquirer");
+const idConverter = require("instagram-id-to-url-segment");
 
 // Create a new Instagram API instance
 const api = new apiClient();
@@ -199,18 +200,19 @@ async function convertMessage(type, msg) {
 
     case "media_share": {
       const postObj = msg.media_share;
-      let postUrl = "";
+      let short = "";
 
       if (postObj.carousel_media) {
-        postUrl = postObj.carousel_media[0].image_versions2.candidates[0].url;
+        let objId = postObj.id.substring(0,postObj.id.indexOf("_"));
+        short = "https://www.instagram.com/p/" + idConverter.instagramIdToUrlSegment(objId) + "/";
       } else if (postObj.image_versions2) {
-        postUrl = postObj.image_versions2.candidates[0].url;
+        let postUrl = postObj.image_versions2.candidates[0].url;
+        short = await tinyurl.shorten(postUrl);
       } else {
         signale.warn("UNSUPPORTED POST TYPE", type, msg);
         return "`[SHARED POST] This post type is unsupported.`";
       }
 
-      const short = await tinyurl.shorten(postUrl);
       let text = `\`[SHARED POST] This post was posted by @${postObj.user.username}.`;
 
       if (postObj.caption) { text += ` Caption: ${postObj.caption.text}`; }

--- a/instagram.js
+++ b/instagram.js
@@ -203,10 +203,10 @@ async function convertMessage(type, msg) {
       let short = "";
 
       if (postObj.carousel_media) {
-        let objId = postObj.id.substring(0,postObj.id.indexOf("_"));
+        const objId = postObj.id.substring(0,postObj.id.indexOf("_"));
         short = "https://www.instagram.com/p/" + idConverter.instagramIdToUrlSegment(objId) + "/";
       } else if (postObj.image_versions2) {
-        let postUrl = postObj.image_versions2.candidates[0].url;
+        const postUrl = postObj.image_versions2.candidates[0].url;
         short = await tinyurl.shorten(postUrl);
       } else {
         signale.warn("UNSUPPORTED POST TYPE", type, msg);

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "discord.js": "^11.5.0",
     "git-rev-sync": "^1.12.0",
     "inquirer": "^7.0.0",
+    "instagram-id-to-url-segment": "^0.0.0",
     "instagram-private-api": "^1.8.0",
     "signale": "^1.4.0",
     "tinyurl": "^1.1.4"


### PR DESCRIPTION
Added instagram-id-to-url-segment as dependency. I don't have previous node.js experience so i'm not sure if other files need to be changed.

From what i gathered from the unfriendly api documentation and github issues page. This seems to be the way of getting a link of a post, [dependency included](https://github.com/dilame/instagram-private-api/issues/1501).

It feels unsafe to click on shortened links. So i left them at full length.

When i started testing, Discord made a preview box of public Instagram posts, images included. It was perfect!
Sadly now it doesn't seem to work. Don't really know why. Perhaps you want to test if it works for you?

Anyway, let me know if my code needs some tweaking.
